### PR TITLE
add option for currency argument to be a string

### DIFF
--- a/lib/changer.rb
+++ b/lib/changer.rb
@@ -1,8 +1,12 @@
 require_relative 'currency'
 class Currency
-  attr_accessor :value
-  attr_reader :type
-  TYPES = [:usd, :eur, :jpy, :gbp, :aud, :cad, :cny, :hkd, :nzd, :chf]
+  attr_reader :type, :value
+  currency_symbols = [:usd, :eur, :jpy, :gbp, :aud, :cad, :cny, :hkd, :nzd, :chf]
+
+  currency_strings = currency_symbols.map(&:to_s)
+
+  TYPES = currency_symbols + currency_strings
+
   # Create a new Currency object
   #
   #
@@ -124,7 +128,8 @@ class Currency
   end
 
   def verify_valid?(to_type, amount)
-    return false unless amount.is_a?(Numeric) && to_type.is_a?(Symbol)
+    return false unless amount.is_a?(Numeric) && 
+      (to_type.is_a?(Symbol) || to_type.is_a?(String))
 
     amount >= 0.0 && TYPES.include?(to_type)
   end

--- a/test/test_changer.rb
+++ b/test/test_changer.rb
@@ -7,6 +7,9 @@ class CurrencyTest < MiniTest::Test
   def test_new_returns_currency_object
     bill = Currency.new(:usd, 3)
     assert_equal true, bill.is_a?(Currency)
+
+    bill = Currency.new('usd', 3)
+    assert_equal true, bill.is_a?(Currency)
   end
 
   def test_valid_types


### PR DESCRIPTION
This revision has only changes to the contents of  `changer.rb`. The filenames were not switched.